### PR TITLE
Develop

### DIFF
--- a/.github/workflows/G-Build Main Pi Services.yml
+++ b/.github/workflows/G-Build Main Pi Services.yml
@@ -23,7 +23,7 @@ env:
   LOCAL_BASE_REGISTRY: ""
   # IP адрес и порт локального registry для self-hosted runners
   # Изменить при необходимости переноса на другой сервер
-  SELF_HOSTED_REGISTRY_HOST: 192.168.1.125:5000
+  SELF_HOSTED_REGISTRY_HOST: 10.1.1.148:5000
   SELF_HOSTED_REGISTRY_PREFIX: krikz/rob_box_base
 
 jobs:

--- a/.github/workflows/L-Deploy and Verify.yml
+++ b/.github/workflows/L-Deploy and Verify.yml
@@ -50,7 +50,7 @@ jobs:
     # Всегда используем self-hosted runner, так как:
     # - Raspberry Pi устройства в локальной сети (10.1.1.x) недоступны из GitHub hosted runners
     # - Требуется SSH доступ к устройствам
-    # - Локальный registry (localhost:5000) доступен только на self-hosted машине
+    # - Локальный registry (10.1.1.148:5000) доступен только на self-hosted машине
     runs-on: self-hosted
     permissions:
       contents: read
@@ -94,8 +94,8 @@ jobs:
               echo "registry_display=GitHub Container Registry (ghcr.io)" >> $GITHUB_ENV
               ;;
             local)
-              echo "SERVICE_IMAGE_PREFIX=localhost:5000/krikz/rob_box" >> $GITHUB_ENV
-              echo "registry_display=Local Build Machine Registry (localhost:5000)" >> $GITHUB_ENV
+              echo "SERVICE_IMAGE_PREFIX=10.1.1.148:5000/krikz/rob_box" >> $GITHUB_ENV
+              echo "registry_display=Local Build Machine Registry (10.1.1.148:5000)" >> $GITHUB_ENV
               ;;
             skip)
               echo "SERVICE_IMAGE_PREFIX=ghcr.io/krikz/rob_box" >> $GITHUB_ENV

--- a/docker/build/scripts/build_and_push_base_images.sh
+++ b/docker/build/scripts/build_and_push_base_images.sh
@@ -9,8 +9,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$(dirname "$(dirname "$SCRIPT_DIR")")")"
 BASE_DIR="$PROJECT_ROOT/docker/base"
 
-LOCAL_REGISTRY="10.1.1.148:5000"
-APT_PROXY="http://10.1.1.148:3142"
+LOCAL_REGISTRY="10.1.1.5:5000"
+APT_PROXY="http://10.1.1.5:3142"
 PLATFORM="linux/arm64"
 
 echo "🏗️  Сборка базовых образов для локального registry..."

--- a/docker/build/scripts/check_base_images_status.sh
+++ b/docker/build/scripts/check_base_images_status.sh
@@ -25,7 +25,7 @@ fi
 # Проверка локального registry
 echo "📦 Images in local registry:"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-curl -s http://10.1.1.148:5000/v2/krikz/rob_box_base/tags/list | jq -r '.tags[]' 2>/dev/null || echo "❌ Failed to query registry"
+curl -s http://10.1.1.5:5000/v2/krikz/rob_box_base/tags/list | jq -r '.tags[]' 2>/dev/null || echo "❌ Failed to query registry"
 echo ""
 
 # Статистика
@@ -35,7 +35,7 @@ EXPECTED=("ros2-zenoh" "rtabmap" "pcl" "depthai")
 FOUND=0
 
 for img in "${EXPECTED[@]}"; do
-    if curl -s "http://10.1.1.148:5000/v2/krikz/rob_box_base/tags/list" | grep -q "\"$img\""; then
+    if curl -s "http://10.1.1.5:5000/v2/krikz/rob_box_base/tags/list" | grep -q "\"$img\""; then
         echo "✅ $img - FOUND"
         ((FOUND++))
     else

--- a/docker/build/scripts/test_apt_cache.sh
+++ b/docker/build/scripts/test_apt_cache.sh
@@ -13,7 +13,7 @@ if ! curl -f http://localhost:3142/acng-report.html > /dev/null 2>&1; then
 fi
 
 # IP адрес для Docker контейнеров (host.docker.internal не всегда работает в Linux)
-APT_PROXY_URL="http://10.1.1.148:3142"
+APT_PROXY_URL="http://10.1.1.5:3142"
 
 echo "🔧 Используем APT прокси: $APT_PROXY_URL"
 
@@ -30,4 +30,4 @@ docker buildx build \
 echo "✅ Тестовая сборка завершена!"
 echo ""
 echo "Проверим кэш APT:"
-echo "http://10.1.1.148:3142/acng-report.html"
+echo "http://10.1.1.5:3142/acng-report.html"

--- a/docker/build/scripts/test_apt_cache_simple.sh
+++ b/docker/build/scripts/test_apt_cache_simple.sh
@@ -13,7 +13,7 @@ if ! curl -f http://localhost:3142/acng-report.html > /dev/null 2>&1; then
 fi
 
 # IP адрес для Docker контейнеров
-APT_PROXY_URL="http://10.1.1.148:3142"
+APT_PROXY_URL="http://10.1.1.5:3142"
 
 echo "🔧 Используем APT прокси: $APT_PROXY_URL"
 
@@ -57,7 +57,7 @@ docker buildx build \
 echo "✅ Тестовая сборка завершена!"
 echo ""
 echo "📊 Проверяем статистику APT кэша:"
-echo "http://10.1.1.148:3142/acng-report.html"
+echo "http://10.1.1.5:3142/acng-report.html"
 
 # Проверяем размер кэша
 echo ""


### PR DESCRIPTION
This pull request updates the configuration to use new IP addresses for the local Docker registry and APT proxy across workflow files and build/test scripts. The changes ensure that all references to the local registry and proxy point to the new server addresses, improving consistency and connectivity for self-hosted runners and Docker builds.

**Registry address updates:**
* Updated the local Docker registry address from `192.168.1.125:5000` and `10.1.1.148:5000` to `10.1.1.148:5000` in `.github/workflows/G-Build Main Pi Services.yml` and `.github/workflows/L-Deploy and Verify.yml`, ensuring workflows use the correct registry host. [[1]](diffhunk://#diff-0374f7b8909377c83c8f4c47399aa0ad5ad0c30b49e0702c6629b097b5364778L26-R26) [[2]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L53-R53) [[3]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L97-R98)

**APT proxy and registry address updates in build/test scripts:**
* Changed the APT proxy and registry IP addresses from `10.1.1.148` to `10.1.1.5` in `docker/build/scripts/build_and_push_base_images.sh`, `docker/build/scripts/check_base_images_status.sh`, `docker/build/scripts/test_apt_cache.sh`, and `docker/build/scripts/test_apt_cache_simple.sh` for both build and cache status checks. [[1]](diffhunk://#diff-4b56fe61e26a8a7e810a269a66a2341faa21262d47bdeef0add1fd4bcefea820L12-R13) [[2]](diffhunk://#diff-de65b289c33d38d9bc54637105c278bda1abe856623cb1c15e879470e8a5f7c0L28-R28) [[3]](diffhunk://#diff-de65b289c33d38d9bc54637105c278bda1abe856623cb1c15e879470e8a5f7c0L38-R38) [[4]](diffhunk://#diff-aa5eececf9abca674f43365ebf4cd02170dab4394eae25f6287d38ef546a5259L16-R16) [[5]](diffhunk://#diff-aa5eececf9abca674f43365ebf4cd02170dab4394eae25f6287d38ef546a5259L33-R33) [[6]](diffhunk://#diff-b065a60df2c6c838f1a9b811356c1a9d10897849ae7c63fc3b21f4b99c56f281L16-R16) [[7]](diffhunk://#diff-b065a60df2c6c838f1a9b811356c1a9d10897849ae7c63fc3b21f4b99c56f281L60-R60)