### PR TITLE
Develop

### DIFF
--- a/.github/workflows/L-Deploy and Verify.yml
+++ b/.github/workflows/L-Deploy and Verify.yml
@@ -367,10 +367,10 @@ jobs:
           STATUS=$(sshpass -p 'open' ssh -o StrictHostKeyChecking=no ros2@${{ env.vision_pi_ip }} \
             'cd ~/rob_box_project/docker/vision && docker compose ps --format json')
 
-          echo "$STATUS" | jq -r '.[] | "  \(.Name): \(.State)"'
+          echo "$STATUS" | jq -r '"  \(.Name): \(.State)"'
 
           # Проверяем наличие падших контейнеров
-          FAILED_COUNT=$(echo "$STATUS" | jq -r '.[] | select(.State != "running") | .Name' | wc -l)
+          FAILED_COUNT=$(echo "$STATUS" | jq -r 'select(.State != "running") | .Name' | wc -l)
           echo "failed_count=$FAILED_COUNT" >> $GITHUB_OUTPUT
 
           if [ "$FAILED_COUNT" -gt 0 ]; then
@@ -392,10 +392,10 @@ jobs:
           STATUS=$(sshpass -p 'open' ssh -o StrictHostKeyChecking=no ros2@${{ env.main_pi_ip }} \
             'cd ~/rob_box_project/docker/main && docker compose ps --format json')
 
-          echo "$STATUS" | jq -r '.[] | "  \(.Name): \(.State)"'
+          echo "$STATUS" | jq -r '"  \(.Name): \(.State)"'
 
           # Проверяем наличие падших контейнеров
-          FAILED_COUNT=$(echo "$STATUS" | jq -r '.[] | select(.State != "running") | .Name' | wc -l)
+          FAILED_COUNT=$(echo "$STATUS" | jq -r 'select(.State != "running") | .Name' | wc -l)
           echo "failed_count=$FAILED_COUNT" >> $GITHUB_OUTPUT
 
           if [ "$FAILED_COUNT" -gt 0 ]; then
@@ -420,7 +420,7 @@ jobs:
 
           # Получаем список контейнеров
           CONTAINERS=$(sshpass -p 'open' ssh -o StrictHostKeyChecking=no ros2@${{ env.vision_pi_ip }} \
-            'cd ~/rob_box_project/docker/vision && docker compose ps --format json' | jq -r '.[].Name')
+            'cd ~/rob_box_project/docker/vision && docker compose ps --format json' | jq -r '.Name')
 
           CRITICAL_COUNT=0
           WARNING_COUNT=0
@@ -479,7 +479,7 @@ jobs:
 
           # Получаем список контейнеров
           CONTAINERS=$(sshpass -p 'open' ssh -o StrictHostKeyChecking=no ros2@${{ env.main_pi_ip }} \
-            'cd ~/rob_box_project/docker/main && docker compose ps --format json' | jq -r '.[].Name')
+            'cd ~/rob_box_project/docker/main && docker compose ps --format json' | jq -r '.Name')
 
           CRITICAL_COUNT=0
           WARNING_COUNT=0


### PR DESCRIPTION
This pull request makes several small but important corrections to how the GitHub Actions workflow processes and parses Docker container status information using `jq`. The main focus is to fix the `jq` queries so that they correctly handle the JSON output from `docker compose ps --format json`, which is an array of objects.

**Workflow script parsing fixes:**

* Updated `jq` queries in status output and failed container counting to remove unnecessary array iteration, ensuring correct parsing of the JSON output from `docker compose ps --format json`. (`.github/workflows/L-Deploy and Verify.yml`) [[1]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L370-R373) [[2]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L395-R398)
* Fixed the container name extraction by changing the `jq` filter from `.[].Name` to `.Name`, aligning with the updated parsing logic and expected input structure. (`.github/workflows/L-Deploy and Verify.yml`) [[1]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L423-R423) [[2]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L482-R482)