### PR TITLE
feat(ci): use workflow branch for deployment instead of manual input

### DIFF
--- a/.github/workflows/L-Deploy and Verify.yml
+++ b/.github/workflows/L-Deploy and Verify.yml
@@ -12,15 +12,6 @@ name: "L: Deploy and Verify"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Ветка для деплоя'
-        required: true
-        default: 'main'
-        type: choice
-        options:
-          - main
-          - develop
-          - feature/test
       environment:
         description: 'Целевое окружение'
         required: true
@@ -60,7 +51,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 1
           clean: true
 
@@ -104,7 +95,7 @@ jobs:
               ;;
           esac
 
-          echo "branch=${{ inputs.branch }}" >> $GITHUB_OUTPUT
+          echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           echo "timestamp=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
 
           # Установка sshpass для автоматической аутентификации
@@ -228,7 +219,7 @@ jobs:
           echo "🔍 DRY RUN MODE - No actual deployment"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo ""
-          echo "Branch: ${{ inputs.branch }}"
+          echo "Branch: ${{ github.ref_name }}"
           echo "Environment: ${{ inputs.environment }}"
           echo "Image Tag: ${{ env.IMAGE_TAG }}"
           echo "Registry: ${{ env.registry_display }}"
@@ -253,14 +244,14 @@ jobs:
         if: '!inputs.dry_run'
         run: |
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "📥 Updating Vision Pi code from branch: ${{ inputs.branch }}"
+          echo "📥 Updating Vision Pi code from branch: ${{ github.ref_name }}"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
           sshpass -p 'open' ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ros2@${{ env.vision_pi_ip }} \
             "cd ~/rob_box_project && \
              GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' git fetch origin && \
-             git checkout ${{ inputs.branch }} && \
-             GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' git pull origin ${{ inputs.branch }}"
+             git checkout ${{ github.ref_name }} && \
+             GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' git pull origin ${{ github.ref_name }}"
 
       - name: "[Vision Pi] Pull Docker Images"
         if: '!inputs.dry_run && inputs.registry_source != ''skip'''
@@ -307,14 +298,14 @@ jobs:
         if: '!inputs.dry_run'
         run: |
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "📥 Updating Main Pi code from branch: ${{ inputs.branch }}"
+          echo "📥 Updating Main Pi code from branch: ${{ github.ref_name }}"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
           sshpass -p 'open' ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ros2@${{ env.main_pi_ip }} \
             "cd ~/rob_box_project && \
              GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' git fetch origin && \
-             git checkout ${{ inputs.branch }} && \
-             GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' git pull origin ${{ inputs.branch }}"
+             git checkout ${{ github.ref_name }} && \
+             GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' git pull origin ${{ github.ref_name }}"
 
       - name: "[Main Pi] Pull Docker Images"
         if: '!inputs.dry_run && inputs.registry_source != ''skip'''
@@ -738,7 +729,7 @@ jobs:
           # Формируем описание issue
           ISSUE_BODY="## Deployment Issue Report
 
-          **Branch:** \`${{ inputs.branch }}\`
+          **Branch:** \`${{ github.ref_name }}\`
           **Environment:** \`${{ inputs.environment }}\`
           **Timestamp:** ${{ steps.setup.outputs.timestamp }}
           **Workflow Run:** [#${{ github.run_number }}](${{
@@ -807,7 +798,7 @@ jobs:
 
           # Создаем issue
           gh issue create \
-            --title "$TITLE: ${{ inputs.branch }} → ${{ inputs.environment }}" \
+            --title "$TITLE: ${{ github.ref_name }} → ${{ inputs.environment }}" \
             --body "$ISSUE_BODY" \
             --label "$LABEL" \
             --assignee "$ASSIGNEE"
@@ -823,7 +814,7 @@ jobs:
           echo "📊 DEPLOYMENT SUMMARY"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo ""
-          echo "Branch: ${{ inputs.branch }}"
+          echo "Branch: ${{ github.ref_name }}"
           echo "Environment: ${{ inputs.environment }}"
           echo "Image Tag: ${{ env.IMAGE_TAG }}"
           echo "Registry: ${{ env.registry_display }}"
@@ -872,7 +863,7 @@ jobs:
           echo ""
           echo "This was a dry run. No actual deployment was performed."
           echo "The workflow would have deployed:"
-          echo "  Branch: ${{ inputs.branch }}"
+          echo "  Branch: ${{ github.ref_name }}"
           echo "  Environment: ${{ inputs.environment }}"
           echo "  Image Tag: ${{ env.IMAGE_TAG }}"
           echo "  Registry: ${{ env.registry_display }}"


### PR DESCRIPTION
This pull request simplifies the deployment workflow by removing the manual selection of the deployment branch and instead automatically using the branch that triggered the workflow. All references to the branch input have been updated to use the GitHub context variable for the current branch, streamlining the deployment process and reducing the chance for user error.

**Workflow input simplification and automation:**

* Removed the `branch` input from the workflow dispatch options, so users no longer need to manually select a branch when triggering the workflow.
* Updated all references from `inputs.branch` to `github.ref_name` throughout the workflow to automatically use the branch that initiated the workflow run. This affects repository checkout, deployment scripts, logging, and issue creation. [[1]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L63-R54) [[2]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L107-R98) [[3]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L231-R222) [[4]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L256-R254) [[5]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L310-R308) [[6]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L741-R732) [[7]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L810-R801) [[8]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L826-R817) [[9]](diffhunk://#diff-36e5f862aa4d1dfa394cd16410b9321277edf3b927bef9e06f735331daec9f07L875-R866)Removed 'branch' input parameter from deployment workflow. Now uses 'Use workflow from' dropdown to select branch for deployment.

Benefits:
- Simpler UI - one less parameter to fill
- No typos in branch names
- Branch dropdown shows all available branches
- More intuitive workflow

Usage:
1. Select branch from 'Use workflow from' dropdown
2. Choose environment (production/staging/test)
3. Choose registry source (github/local/skip)
4. Run workflow