### PR TITLE
Enhance security policy and deployment processes

### DIFF
--- a/.github/workflows/L-Integration Tests.yml
+++ b/.github/workflows/L-Integration Tests.yml
@@ -80,11 +80,14 @@ jobs:
       # ── Определить тег ─────────────────────────────────────────────────────
       - name: Determine image tag
         id: tag
+        env:
+          INPUT_IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+          WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
         run: |
-          if [ -n "${{ github.event.inputs.image_tag }}" ]; then
-            TAG="${{ github.event.inputs.image_tag }}"
+          if [ -n "$INPUT_IMAGE_TAG" ]; then
+            TAG="$INPUT_IMAGE_TAG"
           else
-            BRANCH="${{ github.event.workflow_run.head_branch || github.ref_name }}"
+            BRANCH="$WORKFLOW_BRANCH"
             case "$BRANCH" in
               main)                 TAG="latest" ;;
               develop)              TAG="dev" ;;

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -45,3 +45,22 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+    - name: Cache
+      uses: actions/cache@v5.0.4
+      with:
+        # A list of files, directories, and wildcard patterns to cache and restore
+        path: 
+        # An explicit key for restoring and saving the cache
+        key: 
+        # An ordered multiline string listing the prefix-matched keys, that are used for restoring stale cache if no cache hit occurred for key. Note `cache-hit` returns false in this case.
+        restore-keys: # optional
+        # The chunk size used to split up large files during upload, in bytes
+        upload-chunk-size: # optional
+        # An optional boolean when enabled, allows windows runners to save or restore caches that can be restored or saved respectively on other platforms
+        enableCrossOsArchive: # optional, default is false
+        # Fail the workflow if cache entry is not found
+        fail-on-cache-miss: # optional, default is false
+        # Check if a cache entry exists for the given input(s) (key, restore-keys) without downloading the cache
+        lookup-only: # optional, default is false
+        # Run the post step to save the cache even if another step before fails
+        save-always: # optional, default is false


### PR DESCRIPTION
This pull request adds a caching step to the GitHub Actions workflow in `.github/workflows/defender-for-devops.yml`. The new step uses the `actions/cache` action, which can help speed up workflow runs by reusing dependencies or files from previous runs.

Workflow improvements:

* Added a new "Cache" step using `actions/cache@v5.0.4` to the workflow, with configurable options for caching files and directories, cache keys, restore keys, chunk size, cross-OS archiving, and other behaviors. This can improve workflow efficiency by reusing cached data between runs.