### PR TITLE
Configure Dependabot for GitHub Actions, Pip, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,62 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot version updates for rob_box_project
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Covered ecosystems:
+#   github-actions — workflow action versions (e.g. actions/checkout@v4)
+#   pip            — Python deps in ROS 2 packages and Docker service builds
+#   docker         — FROM base images in all service Dockerfiles
+#
+# All updates are grouped per ecosystem → at most 3 PRs/week.
+# Internal ghcr.io/krikz/* images are ignored (managed by CI, not public registry).
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+
+  # ── GitHub Actions ────────────────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
-      
+      day: "monday"
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # ── Python (pip) ──────────────────────────────────────────────────────────
+  # ROS 2 package requirements + Docker service build requirements
+  - package-ecosystem: "pip"
+    directories:
+      - "/src/rob_box_voice"
+      - "/src/rob_box_perception"
+      - "/docker/main/perception"
+      - "/docker/vision/voice_base"
+      - "/docker/vision/voice_assistant"
+      - "/tools/animation_editor"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      python-deps:
+        patterns: ["*"]
+
+  # ── Docker base images (Dockerfiles) ──────────────────────────────────────
+  # Scans FROM lines in all service Dockerfiles under docker/main/ and docker/vision/
+  # Glob: /docker/main/* → each service subdir (lslidar, nav2, perception, …)
+  #       /docker/vision/* → each service subdir (voice_assistant, oak-d, …)
+  #       /docker/vision/test/* → test service subdirs (mock_llm, ollama, …)
+  - package-ecosystem: "docker"
+    directories:
+      - "/docker/main/*"
+      - "/docker/vision/*"
+      - "/docker/vision/test/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    ignore:
+      # Internal images are built by our CI — no public registry updates available
+      - dependency-name: "ghcr.io/krikz/*"
+      - dependency-name: "10.1.1.249:5000/*"
+    groups:
+      docker-base-images:
+        patterns: ["*"]
+

--- a/docker/vision/.image-versions.dev
+++ b/docker/vision/.image-versions.dev
@@ -1,10 +1,10 @@
 # Vision Pi image versions — staging (develop branch)
 # Managed automatically by CI (L-Build Single Service workflow)
 
-OAK_D_TAG=dev-d4da183
-RTABMAP_SYNC_TAG=dev-d4da183
-LED_MATRIX_TAG=dev-d4da183
-CEILING_CAMERA_TAG=dev-d4da183
-VOICE_RESOURCES_TAG=dev-d4da183
-VOICE_ASSISTANT_TAG=dev-d4da183
-TELEGRAM_BOT_TAG=dev-d4da183
+OAK_D_TAG=dev-d563d69
+RTABMAP_SYNC_TAG=dev-d563d69
+LED_MATRIX_TAG=dev-d563d69
+CEILING_CAMERA_TAG=dev-d563d69
+VOICE_RESOURCES_TAG=dev-d563d69
+VOICE_ASSISTANT_TAG=dev-d563d69
+TELEGRAM_BOT_TAG=dev-d563d69


### PR DESCRIPTION
This pull request updates the Dependabot configuration to provide comprehensive and well-documented automation for dependency updates across GitHub Actions, Python (pip), and Docker images. It also bumps the development image tags for several vision services to a new version.

Dependabot configuration improvements:

* Expanded and clarified the `.github/dependabot.yml` file to explicitly cover GitHub Actions, Python dependencies in multiple locations, and Docker base images, grouping updates by ecosystem and limiting to three PRs per week.
* Added documentation and comments to the configuration for easier maintenance and onboarding.
* Configured internal Docker images (e.g., `ghcr.io/krikz/*`) to be ignored, as they are managed by CI and not available on public registries.

Development image version updates:

* Updated all service image tags in `docker/vision/.image-versions.dev` from `dev-d4da183` to `dev-d563d69`, ensuring all relevant vision services use the latest development builds.