### PR TITLE
Develop

### DIFF
--- a/docker/main/perception/Dockerfile
+++ b/docker/main/perception/Dockerfile
@@ -40,7 +40,7 @@ COPY docker/main/perception/requirements.txt /tmp/perception_requirements.txt
 
 # 4. Устанавливаем Python зависимости (кэшируется отдельно от кода)
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
-    pip3 install --no-cache-dir -r /tmp/perception_requirements.txt && \
+    pip3 install --retries 5 --timeout 120 -r /tmp/perception_requirements.txt && \
     rm /tmp/perception_requirements.txt
 
 # 5. Копируем ресурсы (prompts) - изменяются иногда

--- a/docker/vision/.image-versions.dev
+++ b/docker/vision/.image-versions.dev
@@ -1,10 +1,10 @@
 # Vision Pi image versions — staging (develop branch)
 # Managed automatically by CI (L-Build Single Service workflow)
 
-OAK_D_TAG=dev-d563d69
-RTABMAP_SYNC_TAG=dev-d563d69
-LED_MATRIX_TAG=dev-d563d69
-CEILING_CAMERA_TAG=dev-d563d69
-VOICE_RESOURCES_TAG=dev-d563d69
-VOICE_ASSISTANT_TAG=dev-d563d69
-TELEGRAM_BOT_TAG=dev-d563d69
+OAK_D_TAG=dev-1ed5eb0
+RTABMAP_SYNC_TAG=dev-1ed5eb0
+LED_MATRIX_TAG=dev-1ed5eb0
+CEILING_CAMERA_TAG=dev-1ed5eb0
+VOICE_RESOURCES_TAG=dev-1ed5eb0
+VOICE_ASSISTANT_TAG=dev-1ed5eb0
+TELEGRAM_BOT_TAG=dev-1ed5eb0

--- a/docker/vision/voice_base/Dockerfile
+++ b/docker/vision/voice_base/Dockerfile
@@ -78,7 +78,7 @@ RUN pip3 install --no-cache-dir --upgrade pip "setuptools>=59.6.0,<68" wheel
 COPY requirements.txt /tmp/requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked \
-    pip3 install -r /tmp/requirements.txt && \
+    pip3 install --retries 5 --timeout 120 -r /tmp/requirements.txt && \
     rm /tmp/requirements.txt
 
 # ============================================================================
@@ -87,7 +87,7 @@ RUN --mount=type=cache,target=/root/.cache,sharing=locked \
 RUN cd /tmp && \
     git clone --depth 1 https://github.com/respeaker/usb_4_mic_array.git && \
     cd usb_4_mic_array && \
-    pip3 install --no-cache-dir -r requirements.txt && \
+    pip3 install --retries 5 --timeout 120 -r requirements.txt && \
     cp tuning.py /usr/local/bin/ && \
     cp dfu.py /usr/local/bin/ && \
     chmod +x /usr/local/bin/tuning.py /usr/local/bin/dfu.py && \

--- a/docker/vision/voice_base/Dockerfile
+++ b/docker/vision/voice_base/Dockerfile
@@ -70,7 +70,7 @@ RUN apt-get update && apt-get install -y debconf-utils \
 # ============================================================================
 # Python базовые инструменты (отдельный слой, не зависит от requirements.txt)
 # ============================================================================
-RUN pip3 install --no-cache-dir --upgrade pip "setuptools>=59.6.0,<68" wheel
+RUN pip3 install --no-cache-dir --retries 5 --timeout 120 --upgrade pip "setuptools>=59.6.0,<68" wheel
 
 # ============================================================================
 # Python зависимости

--- a/docker/vision/voice_base/Dockerfile
+++ b/docker/vision/voice_base/Dockerfile
@@ -68,12 +68,16 @@ RUN apt-get update && apt-get install -y debconf-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================================================
+# Python базовые инструменты (отдельный слой, не зависит от requirements.txt)
+# ============================================================================
+RUN pip3 install --no-cache-dir --upgrade pip "setuptools>=59.6.0,<68" wheel
+
+# ============================================================================
 # Python зависимости
 # ============================================================================
 COPY requirements.txt /tmp/requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked \
-    pip3 install --no-cache-dir --upgrade pip "setuptools>=59.6.0,<68" wheel && \
     pip3 install -r /tmp/requirements.txt && \
     rm /tmp/requirements.txt
 


### PR DESCRIPTION
This pull request updates Docker build processes for the perception and vision services to improve reliability when installing Python dependencies. The main changes increase pip's retry and timeout settings during installation steps, which should help reduce failures due to network instability. Additionally, the vision service image tags are updated.

Dependency installation improvements:
* Increased pip retries to 5 and timeout to 120 seconds for all `pip3 install` commands in `docker/main/perception/Dockerfile` and `docker/vision/voice_base/Dockerfile`, removing the `--no-cache-dir` flag for requirements installations. This should make builds more robust against transient network issues. [[1]](diffhunk://#diff-9de62d81529ad241cf568fbe7679c039e3db9a7769ddf23edece0b3356b567adL43-R43) [[2]](diffhunk://#diff-9dd28259b368b5bbe53dfaf320f9917407fbf97949d99d4a1040a35d736fc678R70-R81) [[3]](diffhunk://#diff-9dd28259b368b5bbe53dfaf320f9917407fbf97949d99d4a1040a35d736fc678L86-R90)

Image version updates:
* Updated all image tags in `docker/vision/.image-versions.dev` from `dev-d563d69` to `dev-1ed5eb0`.

Build layer optimization:
* Moved the installation of base Python tools (`pip`, `setuptools`, `wheel`) into a dedicated layer before requirements installation in `docker/vision/voice_base/Dockerfile` for better layer caching and separation.