### PR TITLE
Develop

### DIFF
--- a/docker/main/.image-versions.dev
+++ b/docker/main/.image-versions.dev
@@ -1,11 +1,11 @@
 # Main Pi image versions — staging (develop branch)
 # Managed automatically by CI (L-Build Single Service workflow)
 
-TWIST_MUX_TAG=dev-d4da183
-MICRO_ROS_AGENT_TAG=dev-d4da183
-ROBOT_STATE_PUBLISHER_TAG=dev-d4da183
-RTABMAP_TAG=dev-d4da183
-ROS2_CONTROL_TAG=dev-d4da183
-LSLIDAR_TAG=dev-d4da183
-PERCEPTION_TAG=dev-d4da183
-NAV2_TAG=dev-d4da183
+TWIST_MUX_TAG=dev-307afc6
+MICRO_ROS_AGENT_TAG=dev-307afc6
+ROBOT_STATE_PUBLISHER_TAG=dev-307afc6
+RTABMAP_TAG=dev-307afc6
+ROS2_CONTROL_TAG=dev-307afc6
+LSLIDAR_TAG=dev-307afc6
+PERCEPTION_TAG=dev-307afc6
+NAV2_TAG=dev-307afc6

--- a/docker/main/.image-versions.dev
+++ b/docker/main/.image-versions.dev
@@ -1,11 +1,11 @@
 # Main Pi image versions — staging (develop branch)
 # Managed automatically by CI (L-Build Single Service workflow)
 
-TWIST_MUX_TAG=dev-307afc6
-MICRO_ROS_AGENT_TAG=dev-307afc6
-ROBOT_STATE_PUBLISHER_TAG=dev-307afc6
-RTABMAP_TAG=dev-307afc6
-ROS2_CONTROL_TAG=dev-307afc6
-LSLIDAR_TAG=dev-307afc6
-PERCEPTION_TAG=dev-307afc6
-NAV2_TAG=dev-307afc6
+TWIST_MUX_TAG=dev-a06389e
+MICRO_ROS_AGENT_TAG=dev-a06389e
+ROBOT_STATE_PUBLISHER_TAG=dev-a06389e
+RTABMAP_TAG=dev-a06389e
+ROS2_CONTROL_TAG=dev-a06389e
+LSLIDAR_TAG=dev-a06389e
+PERCEPTION_TAG=dev-a06389e
+NAV2_TAG=dev-a06389e

--- a/docker/main/.image-versions.dev
+++ b/docker/main/.image-versions.dev
@@ -1,11 +1,11 @@
 # Main Pi image versions — staging (develop branch)
 # Managed automatically by CI (L-Build Single Service workflow)
 
-TWIST_MUX_TAG=dev-a06389e
-MICRO_ROS_AGENT_TAG=dev-a06389e
-ROBOT_STATE_PUBLISHER_TAG=dev-a06389e
-RTABMAP_TAG=dev-a06389e
-ROS2_CONTROL_TAG=dev-a06389e
-LSLIDAR_TAG=dev-a06389e
-PERCEPTION_TAG=dev-a06389e
-NAV2_TAG=dev-a06389e
+TWIST_MUX_TAG=dev-f8a1f47
+MICRO_ROS_AGENT_TAG=dev-f8a1f47
+ROBOT_STATE_PUBLISHER_TAG=dev-f8a1f47
+RTABMAP_TAG=dev-f8a1f47
+ROS2_CONTROL_TAG=dev-f8a1f47
+LSLIDAR_TAG=dev-f8a1f47
+PERCEPTION_TAG=dev-f8a1f47
+NAV2_TAG=dev-f8a1f47

--- a/docker/vision/.image-versions.dev
+++ b/docker/vision/.image-versions.dev
@@ -1,10 +1,10 @@
 # Vision Pi image versions — staging (develop branch)
 # Managed automatically by CI (L-Build Single Service workflow)
 
-OAK_D_TAG=dev-a06389e
-RTABMAP_SYNC_TAG=dev-a06389e
-LED_MATRIX_TAG=dev-a06389e
-CEILING_CAMERA_TAG=dev-a06389e
-VOICE_RESOURCES_TAG=dev-a06389e
-VOICE_ASSISTANT_TAG=dev-a06389e
-TELEGRAM_BOT_TAG=dev-a06389e
+OAK_D_TAG=dev-f8a1f47
+RTABMAP_SYNC_TAG=dev-f8a1f47
+LED_MATRIX_TAG=dev-f8a1f47
+CEILING_CAMERA_TAG=dev-f8a1f47
+VOICE_RESOURCES_TAG=dev-f8a1f47
+VOICE_ASSISTANT_TAG=dev-f8a1f47
+TELEGRAM_BOT_TAG=dev-f8a1f47

--- a/docker/vision/.image-versions.dev
+++ b/docker/vision/.image-versions.dev
@@ -1,10 +1,10 @@
 # Vision Pi image versions — staging (develop branch)
 # Managed automatically by CI (L-Build Single Service workflow)
 
-OAK_D_TAG=dev-1ed5eb0
-RTABMAP_SYNC_TAG=dev-1ed5eb0
-LED_MATRIX_TAG=dev-1ed5eb0
-CEILING_CAMERA_TAG=dev-1ed5eb0
-VOICE_RESOURCES_TAG=dev-1ed5eb0
-VOICE_ASSISTANT_TAG=dev-1ed5eb0
-TELEGRAM_BOT_TAG=dev-1ed5eb0
+OAK_D_TAG=dev-307afc6
+RTABMAP_SYNC_TAG=dev-307afc6
+LED_MATRIX_TAG=dev-307afc6
+CEILING_CAMERA_TAG=dev-307afc6
+VOICE_RESOURCES_TAG=dev-307afc6
+VOICE_ASSISTANT_TAG=dev-307afc6
+TELEGRAM_BOT_TAG=dev-307afc6

--- a/docker/vision/.image-versions.dev
+++ b/docker/vision/.image-versions.dev
@@ -1,10 +1,10 @@
 # Vision Pi image versions — staging (develop branch)
 # Managed automatically by CI (L-Build Single Service workflow)
 
-OAK_D_TAG=dev-307afc6
-RTABMAP_SYNC_TAG=dev-307afc6
-LED_MATRIX_TAG=dev-307afc6
-CEILING_CAMERA_TAG=dev-307afc6
-VOICE_RESOURCES_TAG=dev-307afc6
-VOICE_ASSISTANT_TAG=dev-307afc6
-TELEGRAM_BOT_TAG=dev-307afc6
+OAK_D_TAG=dev-a06389e
+RTABMAP_SYNC_TAG=dev-a06389e
+LED_MATRIX_TAG=dev-a06389e
+CEILING_CAMERA_TAG=dev-a06389e
+VOICE_RESOURCES_TAG=dev-a06389e
+VOICE_ASSISTANT_TAG=dev-a06389e
+TELEGRAM_BOT_TAG=dev-a06389e


### PR DESCRIPTION
This pull request updates the development image tags for both the main and vision Pi Docker images to a new version. This ensures all related services are consistently using the latest build.

**Main image version updates:**
* Updated all service tags in `docker/main/.image-versions.dev` to `dev-f8a1f47`.

**Vision image version updates:**
* Updated all service tags in `docker/vision/.image-versions.dev` to `dev-f8a1f47`.