### PR TITLE
Enhance security and update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -67,7 +67,7 @@ jobs:
         "DEFENDER_DIRECTORY=$defenderDirectory" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         "DEFENDER_FILEPATH=$defenderFilePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: Cache Defender CLI packages
-      uses: actions/cache@v5.0.4
+      uses: actions/cache@v5.0.5
       with:
         path: ${{ runner.tool_cache }}\_defender\packages
         key: msdo-${{ runner.os }}-${{ runner.arch }}-${{ env.DEFENDER_CLI_VERSION }}-${{ hashFiles('.github/workflows/defender-for-devops.yml') }}


### PR DESCRIPTION
This pull request updates the version of the `actions/cache` action used in the Defender for DevOps GitHub Actions workflow. This is a minor dependency update to ensure the workflow uses the latest patch version.

Dependency update:

* [`.github/workflows/defender-for-devops.yml`](diffhunk://#diff-71b69d767f4e5c498496c11436abd5218311582fbf6470905dca7b40cddad17bL70-R70): Updated the `actions/cache` action from version `v5.0.4` to `v5.0.5` to use the latest available patch.